### PR TITLE
Use the ZIO `fromCompletionStage` function to convert from a `KafkaFuture[A]` to a `Task[A]` now that `fromCompletionStage` handles cancellation (since 1.0.14)

### DIFF
--- a/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -44,7 +44,6 @@ import zio.blocking.Blocking
 import zio.duration.Duration
 
 import java.util.Optional
-import java.util.concurrent.CompletionException
 import scala.jdk.CollectionConverters._
 
 trait AdminClient {
@@ -508,35 +507,8 @@ object AdminClient extends Accessible[AdminClient] {
       admin    <- make(settings)
     } yield admin).toLayer
 
-  def fromKafkaFuture[R, T](kfv: RIO[R, KafkaFuture[T]]): RIO[R, T] = {
-
-    /*
-     * Inspired by the implementation of [[zio.interop.javaz.fromCompletionStage]].
-     *
-     * See:
-     *   - https://github.com/zio/zio/blob/v1.0.13/core/jvm/src/main/scala/zio/interop/javaz.scala#L47-L80
-     */
-    def unwrapCompletionException(isFatal: Throwable => Boolean)(t: Throwable): Task[Nothing] =
-      t match {
-        case e: CompletionException => Task.fail(e.getCause)
-        case e if !isFatal(e)       => Task.fail(e)
-        case e                      => Task.die(e)
-      }
-
-    kfv.flatMap(f =>
-      Task.effectSuspendTotalWith { (p, _) =>
-        Task.effectAsyncInterrupt[T] { cb =>
-          f.toCompletionStage.whenComplete { (v: T, t: Throwable) =>
-            if (f.isCancelled) cb(ZIO.fiberId.flatMap(id => Task.halt(Cause.interrupt(id))))
-            else if (t ne null) cb(unwrapCompletionException(p.fatal)(t))
-            else cb(Task.succeed(v))
-          }
-
-          Left(ZIO.effectTotal(f.cancel(true)))
-        }
-      }
-    )
-  }
+  def fromKafkaFuture[R, T](kfv: RIO[R, KafkaFuture[T]]): RIO[R, T] =
+    kfv.flatMap(f => ZIO.fromCompletionStage(f.toCompletionStage))
 
   def fromKafkaFutureVoid[R](kfv: RIO[R, KafkaFuture[Void]]): RIO[R, Unit] =
     fromKafkaFuture(kfv).unit


### PR DESCRIPTION
Backport https://github.com/zio/zio-kafka/pull/475 to CDK fork

See discussions that happened in this PR https://github.com/zio/zio-kafka/pull/425 to understand why we were not using the fromCompletionStage stage before