### PR TITLE
Add describeConfigsAsync to AdminClient

### DIFF
--- a/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -106,6 +106,14 @@ trait AdminClient {
   ): Task[Map[ConfigResource, KafkaConfig]]
 
   /**
+   * Get the configuration for the specified resources async.
+   */
+  def describeConfigsAsync(
+    configResources: Iterable[ConfigResource],
+    options: Option[DescribeConfigsOptions] = None
+  ): Task[Map[ConfigResource, Task[KafkaConfig]]]
+
+  /**
    * Get the cluster nodes.
    */
   def describeClusterNodes(options: Option[DescribeClusterOptions] = None): Task[List[Node]]
@@ -318,6 +326,33 @@ object AdminClient extends Accessible[AdminClient] {
           (ConfigResource(configResource), KafkaConfig(config))
         }.toMap
       )
+    }
+
+    /**
+     * Get the configuration for the specified resources async.
+     */
+    override def describeConfigsAsync(
+      configResources: Iterable[ConfigResource],
+      options: Option[DescribeConfigsOptions]
+    ): Task[Map[ConfigResource, Task[KafkaConfig]]] = {
+      val asJava = configResources.map(_.asJava).asJavaCollection
+      blocking
+        .effectBlocking(
+          options
+            .fold(adminClient.describeConfigs(asJava))(opts => adminClient.describeConfigs(asJava, opts.asJava))
+            .values()
+        )
+        .map(
+          _.asScala.map { case (configResource, configFuture) =>
+            (
+              ConfigResource(configResource),
+              ZIO
+                .fromCompletionStage(configFuture.toCompletionStage)
+                .map(config => KafkaConfig(config))
+            )
+
+          }.toMap
+        )
     }
 
     private def describeCluster(options: Option[DescribeClusterOptions]): Task[DescribeClusterResult] =

--- a/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -343,7 +343,7 @@ object AdminClient extends Accessible[AdminClient] {
             .values()
         )
         .map(
-          _.asScala.map { case (configResource, configFuture) =>
+          _.asScala.view.map { case (configResource, configFuture) =>
             (
               ConfigResource(configResource),
               ZIO

--- a/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -333,7 +333,7 @@ object AdminClient extends Accessible[AdminClient] {
      */
     override def describeConfigsAsync(
       configResources: Iterable[ConfigResource],
-      options: Option[DescribeConfigsOptions]
+      options: Option[DescribeConfigsOptions] = None
     ): Task[Map[ConfigResource, Task[KafkaConfig]]] = {
       val asJava = configResources.map(_.asJava).asJavaCollection
       blocking

--- a/src/test/scala/zio/kafka/AdminSpec.scala
+++ b/src/test/scala/zio/kafka/AdminSpec.scala
@@ -144,6 +144,20 @@ object AdminSpec extends DefaultRunnableSpec {
           } yield assert(configs.size)(equalTo(1))
         }
       },
+      testM("describe broker config async") {
+        KafkaTestUtils.withAdmin { client =>
+          for {
+            configTasks <- client.describeConfigsAsync(
+                             List(
+                               ConfigResource(ConfigResourceType.Broker, "0")
+                             )
+                           )
+            configs <- ZIO.foreachPar(configTasks) { case (resource, configTask) =>
+                         configTask.map(config => (resource, config))
+                       }
+          } yield assertTrue(configs.size == 1)
+        }
+      },
       testM("list offsets") {
         KafkaTestUtils.withAdmin { client =>
           val topic    = "topic8"


### PR DESCRIPTION
Some users might not have access to describe config for some resources (ie for some topics). `describeConfigs` method will fail the whole request even if only some resources are restricted. 
The `describeConfigsAsync` allows handling results for each resource so you can still get the results for allowed resources.

This is needed for https://linear.app/conduktor/issue/DT-1926/[bug][be]-authorization-errors-for-accounts-created-on-confluentcloud so we can still compute statistics out of topic configs that the user has access to.

I think this could be potentially backported to the upstream zio-kafka as well.