### PR TITLE
Update kafka to v3.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ lazy val mainScala = scala213
 lazy val allScala  = Seq(scala212, scala3, mainScala)
 
 lazy val zioVersion           = "1.0.16"
-lazy val kafkaClientsVersion  = "3.1.0-cdk"
-lazy val embeddedKafkaVersion = "3.1.0" // Should be the same as kafkaVersion, except for the patch part
+lazy val kafkaClientsVersion  = "3.2.0-cdk"
+lazy val embeddedKafkaVersion = "3.2.0" // Should be the same as kafkaVersion, except for the patch part
 
 lazy val embeddedKafka = "io.github.embeddedkafka" %% "embedded-kafka" % embeddedKafkaVersion % Test
 


### PR DESCRIPTION
This PR is required to migrate properly to confluent 7.2.0.

`zio-kafka` is already on kafka 3.2.0.