### PR TITLE
Add describeLogDirsAsync to AdminClient

### DIFF
--- a/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -194,6 +194,13 @@ trait AdminClient {
   def describeLogDirs(
     brokersId: Iterable[Int]
   ): ZIO[Any, Throwable, Map[Int, Map[String, LogDirDescription]]]
+
+  /**
+   * Describe the log directories of the specified brokers async
+   */
+  def describeLogDirsAsync(
+    brokersId: Iterable[Int]
+  ): ZIO[Any, Throwable, Map[Int, Task[Map[String, LogDirDescription]]]]
 }
 
 object AdminClient extends Accessible[AdminClient] {
@@ -534,6 +541,28 @@ object AdminClient extends Accessible[AdminClient] {
       ).map(
         _.asScala.toMap.bimap(_.intValue, _.asScala.toMap.bimap(identity, LogDirDescription(_)))
       )
+
+    /**
+     * Describe the log directories of the specified brokers async
+     */
+    override def describeLogDirsAsync(
+      brokersId: Iterable[Int]
+    ): ZIO[Any, Throwable, Map[Int, Task[Map[String, LogDirDescription]]]] =
+      blocking
+        .effectBlocking(
+          adminClient.describeLogDirs(brokersId.map(Int.box).asJavaCollection).descriptions()
+        )
+        .map(
+          _.asScala.view.map { case (brokerId, descriptionsFuture) =>
+            (
+              brokerId.intValue(),
+              ZIO
+                .fromCompletionStage(descriptionsFuture.toCompletionStage)
+                .map(_.asScala.view.mapValues(LogDirDescription(_)).toMap)
+            )
+
+          }.toMap
+        )
   }
 
   val live: ZLayer[Has[Blocking.Service] with Has[AdminClientSettings], Throwable, Has[AdminClient]] =

--- a/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -558,7 +558,7 @@ object AdminClient extends Accessible[AdminClient] {
               brokerId.intValue(),
               ZIO
                 .fromCompletionStage(descriptionsFuture.toCompletionStage)
-                .map(_.asScala.view.mapValues(LogDirDescription(_)).toMap)
+                .map(_.asScala.toMap.map { case (k, v) => (k, LogDirDescription(v)) })
             )
 
           }.toMap

--- a/src/test/scala/zio/kafka/AdminSpec.scala
+++ b/src/test/scala/zio/kafka/AdminSpec.scala
@@ -354,6 +354,26 @@ object AdminSpec extends DefaultRunnableSpec {
           )
         }
       },
+      testM("describe log dirs async") {
+        KafkaTestUtils.withAdmin { implicit admin =>
+          for {
+            topicName <- randomTopic
+            _         <- admin.createTopic(AdminClient.NewTopic(topicName, numPartitions = 1, replicationFactor = 1))
+            node      <- admin.describeClusterNodes().head.orElseFail(new NoSuchElementException())
+            logDirs <-
+              admin.describeLogDirsAsync(List(node.id)).flatMap { descriptions =>
+                ZIO.foreachPar(descriptions) { case (brokerId, descriptionAsync) =>
+                  descriptionAsync.map(description => (brokerId, description))
+                }
+              }
+          } yield assert(logDirs)(
+            hasKey(
+              node.id,
+              hasValues(exists(hasField("replicaInfos", _.replicaInfos, hasKey(TopicPartition(topicName, 0)))))
+            )
+          )
+        }
+      },
       test("should correctly handle no node (null) when converting JNode to Node") {
         assert(AdminClient.Node.apply(null))(isNone)
       },


### PR DESCRIPTION
similar to https://github.com/conduktor/zio-kafka/pull/62 to be able to handle errors per broker