### PR TITLE
Prefer `org.apache.kafka.clients.admin.Admin` over `org.apache.kafka.clients.admin.AdminClient` as recommended in `AdminClient` documentation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import scala.sys.process._
 
 import scala.util.Try
 
-lazy val scala212  = "2.12.15"
+lazy val scala212  = "2.12.16"
 lazy val scala213  = "2.13.8"
-lazy val scala3    = "3.1.2"
+lazy val scala3    = "3.1.3"
 lazy val mainScala = scala213
 lazy val allScala  = Seq(scala212, scala3, mainScala)
 
@@ -95,7 +95,7 @@ lazy val kafka =
         "io.conduktor.kafka"         % "kafka-clients"           % kafkaClientsVersion,
         "com.fasterxml.jackson.core" % "jackson-databind"        % "2.13.3",
         "ch.qos.logback"             % "logback-classic"         % "1.2.11"   % Test,
-        "org.scala-lang.modules"    %% "scala-collection-compat" % "2.7.0"
+        "org.scala-lang.modules"    %% "scala-collection-compat" % "2.8.1"
       ) ++ {
         if (scalaBinaryVersion.value == "3")
           Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.1


### PR DESCRIPTION
<img width="709" alt="image" src="https://user-images.githubusercontent.com/1193670/184714447-311f3bb0-20d8-4c00-86a1-0721cee70c82.png">
