### PR TITLE
Avoid throwing and catching InvalidGroupException over and over when consumer don't use any consumer group id

### DIFF
--- a/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -342,6 +342,7 @@ object Consumer {
     for {
       wrapper <- ConsumerAccess.fromJavaConsumer(javaConsumer, settings.closeTimeout)
       runloop <- Runloop(
+                   settings.hasGroupId,
                    wrapper,
                    settings.pollInterval,
                    settings.pollTimeout,

--- a/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -37,6 +37,9 @@ final case class ConsumerSettings(
   def withGroupId(groupId: String): ConsumerSettings =
     withProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
 
+  private[consumer] def hasGroupId: Boolean =
+    properties.contains(ConsumerConfig.GROUP_ID_CONFIG)
+
   def withGroupInstanceId(groupInstanceId: String): ConsumerSettings =
     withProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
 


### PR DESCRIPTION
The zio-kafka consumer was trying to always get consumer group metada even if the consumer wasn't using any id.
This was fine because it was doing into a `Try` but this wasn't good for performance!