### PR TITLE
Drop JDK8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '11', '17' ]
         scala: [ '2.12.15', '2.13.8', '3.1.1' ]
     steps:
       - name: Checkout current branch


### PR DESCRIPTION
Logback 1.4.x is compatible with JDK11+ (https://logback.qos.ch/download.html).
Our recent update with PR #89 broke the CI with JDK8.

I propose to drop the support of JDK8 (at least in our branch) in order to pass the CI and be aligned with the version of logback that we use in our projects.
